### PR TITLE
Change port mapping from 8090:8090 to 8080:8090 on vertx container

### DIFF
--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -2,7 +2,7 @@ vertx:
   image: opendigitaleducation/vertx-service-launcher:1.0.0
   user: "1000:1000"
   ports:
-    - "8090:8090"
+    - "8080:8090"
 #    - "5000:5000"
   volumes:
     - ./assets:/srv/springboard/assets


### PR DESCRIPTION
Change the port to access dockerized entcore from 8090 to 8080 because it is not possible to access the application on a safari mac on browserstack on port 8090 https://www.browserstack.com/question/664.